### PR TITLE
feat: Add settings screen for Pomodoro timer

### DIFF
--- a/flipp_pomodoro/TESTING.md
+++ b/flipp_pomodoro/TESTING.md
@@ -1,0 +1,160 @@
+# Flipp Pomodoro Testing Guide
+
+This document outlines test cases for the Flipp Pomodoro application. As there is currently no dedicated unit testing framework integrated, these tests are described for manual verification or future automation.
+
+## I. Module: `flipp_pomodoro.c` (`FlippPomodoroState` and logic)
+
+This module manages the core Pomodoro timer state and logic, including user-configurable settings.
+
+### 1.1. `flipp_pomodoro__new()`
+*   **Test Case:** Initialization of settings.
+    *   **Action:** Call `flipp_pomodoro__new()`.
+    *   **Expected Output:** The `settings` member of the returned `FlippPomodoroState` should have:
+        *   `work_minutes` = 25
+        *   `short_break_minutes` = 5
+        *   `long_break_minutes` = 30
+    *   **Verification:** Inspect the `state->settings` values.
+
+### 1.2. `flipp_pomodoro__set_settings()`
+*   **Test Case:** Update all settings.
+    *   **Action:**
+        1. Create a `FlippPomodoroState* state = flipp_pomodoro__new();`.
+        2. Create a `FlippPomodoroSettings new_settings = { .work_minutes = 40, .short_break_minutes = 10, .long_break_minutes = 20 };`.
+        3. Call `flipp_pomodoro__set_settings(state, &new_settings);`.
+    *   **Expected Output:** `state->settings` should now reflect the `new_settings` values.
+        *   `work_minutes` = 40
+        *   `short_break_minutes` = 10
+        *   `long_break_minutes` = 20
+    *   **Verification:** Inspect `state->settings` after the call.
+
+### 1.3. `flipp_pomodoro__get_settings()`
+*   **Test Case:** Retrieve current settings.
+    *   **Action:**
+        1. Create `FlippPomodoroState* state = flipp_pomodoro__new();`.
+        2. Modify settings if desired (e.g., using `flipp_pomodoro__set_settings()`).
+        3. Call `FlippPomodoroSettings* retrieved_settings = flipp_pomodoro__get_settings(state);`.
+    *   **Expected Output:** `retrieved_settings` should point to `state->settings`, and its members should match the current settings in `state`.
+    *   **Verification:** Compare `retrieved_settings->work_minutes` etc. with `state->settings.work_minutes`.
+
+### 1.4. `flipp_pomodoro__current_stage_total_duration()`
+This function's behavior depends on the current stage and the settings stored in `FlippPomodoroState`.
+*   **Pre-condition:** `FlippPomodoroState* state` is initialized, and settings can be default or custom.
+*   **Helper:** `TIME_SECONDS_IN_MINUTE` (which is 60)
+
+*   **Test Case 1.4.1:** Focus stage with default settings.
+    *   **Action:**
+        1. `state = flipp_pomodoro__new();` (ensure stage is Focus, which is default).
+        2. Call `duration = flipp_pomodoro__current_stage_total_duration(state);`.
+    *   **Expected Output:** `duration` = 25 * 60 = 1500 seconds.
+    *   **Verification:** Check `duration`.
+
+*   **Test Case 1.4.2:** Short Break stage with custom settings.
+    *   **Action:**
+        1. `state = flipp_pomodoro__new();`
+        2. `FlippPomodoroSettings new_settings = { .work_minutes = 25, .short_break_minutes = 7, .long_break_minutes = 30 };`
+        3. `flipp_pomodoro__set_settings(state, &new_settings);`
+        4. Manually advance stage to Short Break (e.g. `state->current_stage_index = 1;` assuming sequence Focus, Rest, Focus, Rest...)
+        5. Call `duration = flipp_pomodoro__current_stage_total_duration(state);`.
+    *   **Expected Output:** `duration` = 7 * 60 = 420 seconds.
+    *   **Verification:** Check `duration`.
+
+*   **Test Case 1.4.3:** Long Break stage with custom settings.
+    *   **Action:**
+        1. `state = flipp_pomodoro__new();`
+        2. `FlippPomodoroSettings new_settings = { .work_minutes = 50, .short_break_minutes = 10, .long_break_minutes = 45 };`
+        3. `flipp_pomodoro__set_settings(state, &new_settings);`
+        4. Manually advance stage to Long Break (e.g. by setting `state->current_stage_index` appropriately according to `stages_sequence` in `flipp_pomodoro.c`).
+        5. Call `duration = flipp_pomodoro__current_stage_total_duration(state);`.
+    *   **Expected Output:** `duration` = 45 * 60 = 2700 seconds.
+    *   **Verification:** Check `duration`.
+
+
+## II. View: `flipp_pomodoro_settings_view.c`
+
+This module manages the UI for displaying and modifying timer settings.
+
+### 2.1. Setter Functions (e.g., `flipp_pomodoro_settings_view_set_work_time`)
+*   **Pre-condition:** `FlippPomodoroSettingsView* view = flipp_pomodoro_settings_view_alloc();`
+
+*   **Test Case 2.1.1:** Set valid work time.
+    *   **Action:** `flipp_pomodoro_settings_view_set_work_time(view, 35);`
+    *   **Expected Output:** `view->work_time` (internal model) should be 35.
+    *   **Verification:** Inspect `view->work_time` (if accessible directly) or use a corresponding getter.
+
+*   **Test Case 2.1.2:** Set work time above maximum (99).
+    *   **Action:** `flipp_pomodoro_settings_view_set_work_time(view, 100);`
+    *   **Expected Output:** `view->work_time` should be clamped to 99.
+    *   **Verification:** Inspect `view->work_time`.
+
+*   **Test Case 2.1.3:** Set work time to 0 (minimum).
+    *   **Action:** `flipp_pomodoro_settings_view_set_work_time(view, 0);`
+    *   **Expected Output:** `view->work_time` should be 0.
+    *   **Verification:** Inspect `view->work_time`.
+
+*   **(Repeat similar test cases for `_set_short_break_time` and `_set_long_break_time`)**
+
+### 2.2. Getter Functions (e.g., `flipp_pomodoro_settings_view_get_work_time`)
+*   **Pre-condition:** `FlippPomodoroSettingsView* view = flipp_pomodoro_settings_view_alloc();`
+
+*   **Test Case 2.2.1:** Get work time after setting it.
+    *   **Action:**
+        1. `flipp_pomodoro_settings_view_set_work_time(view, 42);`
+        2. `uint8_t val = flipp_pomodoro_settings_view_get_work_time(view);`
+    *   **Expected Output:** `val` should be 42.
+    *   **Verification:** Check `val`.
+
+*   **Test Case 2.2.2:** Get default work time.
+    *   **Action:** `uint8_t val = flipp_pomodoro_settings_view_get_work_time(view);` (immediately after alloc)
+    *   **Expected Output:** `val` should be the default value set in `_alloc()` (e.g., 25).
+    *   **Verification:** Check `val`.
+
+*   **(Repeat similar test cases for `_get_short_break_time` and `_get_long_break_time`)**
+
+### 2.3. Input Handling (in `flipp_pomodoro_settings_view_input_callback`)
+Testing input handling is more complex without UI interaction. These tests describe the expected change in the view's model.
+*   **Pre-condition:** `FlippPomodoroSettingsView* view = flipp_pomodoro_settings_view_alloc();`
+*   **Helper:** `InputEvent event; event.type = InputTypeShort;`
+
+*   **Test Case 2.3.1:** Increment selected item (Work Time).
+    *   **Action:**
+        1. `view->selected_item = 0;` (Work Time)
+        2. `view->work_time = 25;`
+        3. `event.key = InputKeyRight;`
+        4. `flipp_pomodoro_settings_view_input_callback(&event, view);`
+    *   **Expected Output:** `view->work_time` should be 26.
+    *   **Verification:** Check `view->work_time`.
+
+*   **Test Case 2.3.2:** Decrement selected item (Short Break Time) at minimum.
+    *   **Action:**
+        1. `view->selected_item = 1;` (Short Break)
+        2. `view->short_break_time = 0;`
+        3. `event.key = InputKeyLeft;`
+        4. `flipp_pomodoro_settings_view_input_callback(&event, view);`
+    *   **Expected Output:** `view->short_break_time` should remain 0.
+    *   **Verification:** Check `view->short_break_time`.
+
+*   **Test Case 2.3.3:** Increment selected item (Long Break Time) at maximum.
+    *   **Action:**
+        1. `view->selected_item = 2;` (Long Break)
+        2. `view->long_break_time = 99;`
+        3. `event.key = InputKeyRight;`
+        4. `flipp_pomodoro_settings_view_input_callback(&event, view);`
+    *   **Expected Output:** `view->long_break_time` should remain 99.
+    *   **Verification:** Check `view->long_break_time`.
+
+*   **Test Case 2.3.4:** Change selected item (Up/Down).
+    *   **Action:**
+        1. `view->selected_item = 1;`
+        2. `event.key = InputKeyUp;`
+        3. `flipp_pomodoro_settings_view_input_callback(&event, view);`
+    *   **Expected Output:** `view->selected_item` should be 0.
+    *   **Verification:** Check `view->selected_item`.
+
+## III. Scene: `flipp_pomodoro_scene_settings.c`
+
+Integration tests for scenes are typically harder without a running application.
+The main logic points to verify are:
+*   `on_enter`: The settings view is updated with values from `app->state` (via `flipp_pomodoro__get_settings`).
+*   `on_event` (Back button): Values from the settings view are correctly retrieved (via `flipp_pomodoro_settings_view_get_..._time`) and saved to `app->state` (via `flipp_pomodoro__set_settings`).
+
+These would typically be verified by running the app on a device/simulator, navigating to the settings screen, changing values, saving, and then observing if the timer behavior (e.g., stage durations) reflects these new settings.

--- a/flipp_pomodoro/flipp_pomodoro_app.c
+++ b/flipp_pomodoro/flipp_pomodoro_app.c
@@ -78,6 +78,7 @@ FlippPomodoroApp *flipp_pomodoro_app_alloc()
 
     app->timer_view = flipp_pomodoro_view_timer_alloc();
     app->info_view = flipp_pomodoro_info_view_alloc();
+    app->settings_view = flipp_pomodoro_settings_view_alloc();
 
     view_dispatcher_add_view(
         app->view_dispatcher,
@@ -89,6 +90,11 @@ FlippPomodoroApp *flipp_pomodoro_app_alloc()
         FlippPomodoroAppViewInfo,
         flipp_pomodoro_info_view_get_view(app->info_view));
 
+    view_dispatcher_add_view(
+        app->view_dispatcher,
+        FlippPomodoroAppViewSettings,
+        flipp_pomodoro_settings_view_get_view(app->settings_view));
+
     scene_manager_next_scene(app->scene_manager, FlippPomodoroSceneTimer);
     FURI_LOG_I(TAG, "Alloc complete");
     return app;
@@ -98,10 +104,12 @@ void flipp_pomodoro_app_free(FlippPomodoroApp *app)
 {
     view_dispatcher_remove_view(app->view_dispatcher, FlippPomodoroAppViewTimer);
     view_dispatcher_remove_view(app->view_dispatcher, FlippPomodoroAppViewInfo);
+    view_dispatcher_remove_view(app->view_dispatcher, FlippPomodoroAppViewSettings);
     view_dispatcher_free(app->view_dispatcher);
     scene_manager_free(app->scene_manager);
     flipp_pomodoro_view_timer_free(app->timer_view);
     flipp_pomodoro_info_view_free(app->info_view);
+    flipp_pomodoro_settings_view_free(app->settings_view);
     flipp_pomodoro_statistics__destroy(app->statistics);
     flipp_pomodoro__destroy(app->state);
     free(app);

--- a/flipp_pomodoro/flipp_pomodoro_app.h
+++ b/flipp_pomodoro/flipp_pomodoro_app.h
@@ -8,6 +8,7 @@
 #include <notification/notification_messages.h>
 #include "views/flipp_pomodoro_timer_view.h"
 #include "views/flipp_pomodoro_info_view.h"
+#include "views/flipp_pomodoro_settings_view.h"
 
 #include "modules/flipp_pomodoro.h"
 #include "modules/flipp_pomodoro_statistics.h"
@@ -31,6 +32,7 @@ typedef struct
     NotificationApp *notification_app;
     FlippPomodoroTimerView *timer_view;
     FlippPomodoroInfoView *info_view;
+    FlippPomodoroSettingsView *settings_view;
     FlippPomodoroState *state;
     FlippPomodoroStatistics *statistics;
 } FlippPomodoroApp;
@@ -39,4 +41,5 @@ typedef enum
 {
     FlippPomodoroAppViewTimer,
     FlippPomodoroAppViewInfo,
+    FlippPomodoroAppViewSettings,
 } FlippPomodoroAppView;

--- a/flipp_pomodoro/modules/flipp_pomodoro.c
+++ b/flipp_pomodoro/modules/flipp_pomodoro.c
@@ -2,6 +2,7 @@
 #include <furi_hal.h>
 #include "../helpers/time.h"
 #include "flipp_pomodoro.h"
+#include "../services/flipp_pomodoro_settings_storage.h" // For settings_load
 
 PomodoroStage stages_sequence[] = {
     FlippPomodoroStageFocus,
@@ -117,6 +118,9 @@ FlippPomodoroState *flipp_pomodoro__new()
     state->settings.work_minutes = 25;
     state->settings.short_break_minutes = 5;
     state->settings.long_break_minutes = 30;
+
+    // Load persisted settings, potentially overriding the defaults above
+    flipp_pomodoro_settings_load(state);
 
     return state;
 };

--- a/flipp_pomodoro/modules/flipp_pomodoro.c
+++ b/flipp_pomodoro/modules/flipp_pomodoro.c
@@ -67,13 +67,25 @@ void flipp_pomodoro__destroy(FlippPomodoroState *state)
 
 uint32_t flipp_pomodoro__current_stage_total_duration(FlippPomodoroState *state)
 {
-    const int32_t stage_duration_seconds_map[] = {
-        [FlippPomodoroStageFocus] = 25 * TIME_SECONDS_IN_MINUTE,
-        [FlippPomodoroStageRest] = 5 * TIME_SECONDS_IN_MINUTE,
-        [FlippPomodoroStageLongBreak] = 30 * TIME_SECONDS_IN_MINUTE,
-    };
+    PomodoroStage current_stage = flipp_pomodoro__get_stage(state);
+    uint8_t duration_minutes;
 
-    return stage_duration_seconds_map[flipp_pomodoro__get_stage(state)];
+    switch (current_stage) {
+        case FlippPomodoroStageFocus:
+            duration_minutes = state->settings.work_minutes;
+            break;
+        case FlippPomodoroStageRest:
+            duration_minutes = state->settings.short_break_minutes;
+            break;
+        case FlippPomodoroStageLongBreak:
+            duration_minutes = state->settings.long_break_minutes;
+            break;
+        default:
+            // Should not happen
+            duration_minutes = 25;
+            break;
+    }
+    return duration_minutes * TIME_SECONDS_IN_MINUTE;
 };
 
 uint32_t flipp_pomodoro__stage_expires_timestamp(FlippPomodoroState *state)
@@ -100,5 +112,24 @@ FlippPomodoroState *flipp_pomodoro__new()
     const uint32_t now = time_now();
     state->started_at_timestamp = now;
     state->current_stage_index = 0;
+
+    // Initialize settings with default values
+    state->settings.work_minutes = 25;
+    state->settings.short_break_minutes = 5;
+    state->settings.long_break_minutes = 30;
+
     return state;
 };
+
+FlippPomodoroSettings* flipp_pomodoro__get_settings(FlippPomodoroState* state) {
+    furi_assert(state);
+    return &state->settings;
+}
+
+void flipp_pomodoro__set_settings(FlippPomodoroState* state, FlippPomodoroSettings* settings) {
+    furi_assert(state);
+    furi_assert(settings);
+    state->settings.work_minutes = settings->work_minutes;
+    state->settings.short_break_minutes = settings->short_break_minutes;
+    state->settings.long_break_minutes = settings->long_break_minutes;
+}

--- a/flipp_pomodoro/modules/flipp_pomodoro.h
+++ b/flipp_pomodoro/modules/flipp_pomodoro.h
@@ -11,11 +11,19 @@ typedef enum
     FlippPomodoroStageLongBreak,
 } PomodoroStage;
 
+/// @brief Settings for Pomodoro timer durations
+typedef struct {
+    uint8_t work_minutes;
+    uint8_t short_break_minutes;
+    uint8_t long_break_minutes;
+} FlippPomodoroSettings;
+
 /// @brief State of the pomodoro timer
 typedef struct
 {
     uint8_t current_stage_index;
     uint32_t started_at_timestamp;
+    FlippPomodoroSettings settings;
 } FlippPomodoroState;
 
 /// @brief Generates initial state
@@ -53,3 +61,13 @@ bool flipp_pomodoro__is_stage_expired(FlippPomodoroState *state);
 /// @brief Rotate stage of the timer
 /// @param state - pointer to the state of pomorodo.
 void flipp_pomodoro__toggle_stage(FlippPomodoroState *state);
+
+/// @brief Get current timer settings
+/// @param state - pointer to the state of pomorodo.
+/// @returns Pointer to the FlippPomodoroSettings struct
+FlippPomodoroSettings* flipp_pomodoro__get_settings(FlippPomodoroState* state);
+
+/// @brief Set new timer settings
+/// @param state - pointer to the state of pomorodo.
+/// @param settings - pointer to the new FlippPomodoroSettings struct
+void flipp_pomodoro__set_settings(FlippPomodoroState* state, FlippPomodoroSettings* settings);

--- a/flipp_pomodoro/scenes/config/flipp_pomodoro_scene_config.h
+++ b/flipp_pomodoro/scenes/config/flipp_pomodoro_scene_config.h
@@ -1,2 +1,3 @@
 ADD_SCENE(flipp_pomodoro, info, Info)
 ADD_SCENE(flipp_pomodoro, timer, Timer)
+ADD_SCENE(flipp_pomodoro, settings, Settings)

--- a/flipp_pomodoro/scenes/flipp_pomodoro_scene_settings.c
+++ b/flipp_pomodoro/scenes/flipp_pomodoro_scene_settings.c
@@ -1,0 +1,59 @@
+#include "flipp_pomodoro_scene_settings.h"
+#include "../flipp_pomodoro_app.h" // Provides FlippPomodoroApp and scene definitions
+#include "../modules/flipp_pomodoro.h" // Provides flipp_pomodoro__get_settings, etc.
+#include "../views/flipp_pomodoro_settings_view.h"
+#include <gui/scene_manager.h> // For scene navigation
+#include <gui/view_dispatcher.h> // For view dispatcher
+#include <furi.h> // For FURI_LOG_I, UNUSED
+
+// No need for forward declarations, they are in the header
+
+void flipp_pomodoro_scene_settings_on_enter(void* context) {
+    furi_assert(context);
+    FlippPomodoroApp* app = context;
+    FlippPomodoroSettings* settings = flipp_pomodoro__get_settings(app->state);
+
+    // Assuming flipp_pomodoro_settings_view_alloc has been called and app->settings_view is valid
+    // This view should be created and added to view_dispatcher in flipp_pomodoro_app.c
+    // For now, we are focusing on scene logic.
+    if(app->settings_view) {
+        flipp_pomodoro_settings_view_set_work_time(app->settings_view, settings->work_minutes);
+        flipp_pomodoro_settings_view_set_short_break_time(app->settings_view, settings->short_break_minutes);
+        flipp_pomodoro_settings_view_set_long_break_time(app->settings_view, settings->long_break_minutes);
+        view_dispatcher_switch_to_view(app->view_dispatcher, FlippPomodoroAppViewSettings);
+    } else {
+        FURI_LOG_E("FlippPomodoro", "Settings view is null in scene_settings_on_enter");
+    }
+    FURI_LOG_I("FlippPomodoro", "SettingsScene::on_enter completed");
+}
+
+bool flipp_pomodoro_scene_settings_on_event(void* context, SceneManagerEvent event) {
+    furi_assert(context);
+    FlippPomodoroApp* app = context;
+    bool consumed = false;
+
+    if (event.type == SceneManagerEventTypeKey && event.input.type == InputTypeShort && event.input.key == InputKeyBack) {
+        FlippPomodoroSettings new_settings;
+        if(app->settings_view) {
+            new_settings.work_minutes = flipp_pomodoro_settings_view_get_work_time(app->settings_view);
+            new_settings.short_break_minutes = flipp_pomodoro_settings_view_get_short_break_time(app->settings_view);
+            new_settings.long_break_minutes = flipp_pomodoro_settings_view_get_long_break_time(app->settings_view);
+            flipp_pomodoro__set_settings(app->state, &new_settings);
+            FURI_LOG_I("FlippPomodoro", "Settings saved from view.");
+        } else {
+            FURI_LOG_E("FlippPomodoro", "Settings view is null, cannot save settings.");
+            // Optionally, load default or last known good settings if this happens
+        }
+
+        scene_manager_previous_scene(app->scene_manager); // Go back to Timer scene
+        consumed = true;
+    }
+    // Add other event handling for settings modification later (e.g., OK to save, Up/Down to change value)
+
+    return consumed;
+}
+
+void flipp_pomodoro_scene_settings_on_exit(void* context) {
+    UNUSED(context);
+    FURI_LOG_I("FlippPomodoro", "SettingsScene::on_exit");
+}

--- a/flipp_pomodoro/scenes/flipp_pomodoro_scene_settings.h
+++ b/flipp_pomodoro/scenes/flipp_pomodoro_scene_settings.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <gui/scene_manager.h>
+
+// Define the scene handlers
+void flipp_pomodoro_scene_settings_on_enter(void* context);
+bool flipp_pomodoro_scene_settings_on_event(void* context, SceneManagerEvent event);
+void flipp_pomodoro_scene_settings_on_exit(void* context);

--- a/flipp_pomodoro/scenes/flipp_pomodoro_scene_timer.c
+++ b/flipp_pomodoro/scenes/flipp_pomodoro_scene_timer.c
@@ -167,6 +167,12 @@ bool flipp_pomodoro_scene_timer_on_event(void *ctx, SceneManagerEvent event)
     case SceneManagerEventTypeBack:
         scene_manager_next_scene(app->scene_manager, FlippPomodoroSceneInfo);
         return SceneEventConusmed;
+    case SceneManagerEventTypeKey:
+        if (event.input.type == InputTypeLong && event.input.key == InputKeyOk) {
+            scene_manager_next_scene(app->scene_manager, FlippPomodoroSceneSettings);
+            return SceneEventConusmed;
+        }
+        break;
     default:
         break;
     };

--- a/flipp_pomodoro/services/flipp_pomodoro_settings_storage.c
+++ b/flipp_pomodoro/services/flipp_pomodoro_settings_storage.c
@@ -1,0 +1,126 @@
+#include "flipp_pomodoro_settings_storage.h"
+#include "../modules/flipp_pomodoro.h" // For FlippPomodoroState and FlippPomodoroSettings
+#include <storage/storage.h>
+#include <furi.h> // For FURI_LOG_D, FURI_LOG_E, etc.
+
+#define TAG "FlippPomodoroSettingsStorage"
+
+// Helper function to apply default settings
+static void apply_default_settings(FlippPomodoroSettings* settings) {
+    settings->work_minutes = 25;
+    settings->short_break_minutes = 5;
+    settings->long_break_minutes = 30;
+    FURI_LOG_I(TAG, "Applied default settings");
+}
+
+// Helper function to validate settings values
+static bool validate_settings(FlippPomodoroSettings* settings) {
+    bool valid = true;
+    if (settings->work_minutes > 99) {
+        FURI_LOG_W(TAG, "Invalid work_minutes %u, resetting to default.", settings->work_minutes);
+        settings->work_minutes = 25; // Or some other default for this specific field
+        valid = false; // Indicate that at least one value was invalid
+    }
+    if (settings->short_break_minutes > 99) {
+        FURI_LOG_W(TAG, "Invalid short_break_minutes %u, resetting to default.", settings->short_break_minutes);
+        settings->short_break_minutes = 5;
+        valid = false;
+    }
+    if (settings->long_break_minutes > 99) {
+        FURI_LOG_W(TAG, "Invalid long_break_minutes %u, resetting to default.", settings->long_break_minutes);
+        settings->long_break_minutes = 30;
+        valid = false;
+    }
+    // If any value was invalid, it might be good to consider all settings compromised
+    // and reload all defaults, or handle individually as done here.
+    // For simplicity, individual reset is shown. If 'valid' is false, the caller might decide to save these corrected settings.
+    return valid;
+}
+
+
+void flipp_pomodoro_settings_load(FlippPomodoroState* state) {
+    furi_assert(state);
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperApplicationFile* file = storage_file_alloc(storage);
+    bool settings_loaded_successfully = false;
+
+    FURI_LOG_I(TAG, "Attempting to load settings from %s", FLIPP_POMODORO_SETTINGS_FILE_PATH);
+
+    if(storage_file_open(file, FLIPP_POMODORO_SETTINGS_FILE_PATH, FSAM_READ, FSOM_OPEN_EXISTING)) {
+        FURI_LOG_D(TAG, "File opened successfully for reading.");
+        FlippPomodoroSettings temp_settings;
+        if(storage_file_read(file, &temp_settings, sizeof(FlippPomodoroSettings)) == sizeof(FlippPomodoroSettings)) {
+            FURI_LOG_D(TAG, "Successfully read %d bytes from file.", sizeof(FlippPomodoroSettings));
+            if(validate_settings(&temp_settings)) {
+                state->settings = temp_settings;
+                settings_loaded_successfully = true;
+                FURI_LOG_I(TAG, "Settings loaded and validated successfully: W:%u, S:%u, L:%u",
+                    state->settings.work_minutes,
+                    state->settings.short_break_minutes,
+                    state->settings.long_break_minutes);
+            } else {
+                // Validation failed, some values were corrected to defaults.
+                // We'll use these corrected (partially default) settings.
+                state->settings = temp_settings;
+                // It might be good to save these corrected settings back.
+                // For now, we proceed with the corrected ones.
+                FURI_LOG_W(TAG, "Settings validation failed, some values were reset. Using corrected values.");
+                // Consider settings_loaded_successfully = true; here if corrected values are acceptable.
+                // For now, if any value was out of bounds, we'll treat it as a partial success
+                // and the corrected values are now in state->settings.
+                // The next save operation would persist these corrections.
+                settings_loaded_successfully = true; // Or false if we want to force a full default overwrite and save.
+                                                // Let's say true, as validate_settings already corrected them.
+            }
+        } else {
+            FURI_LOG_E(TAG, "Failed to read settings data from file or size mismatch.");
+        }
+        storage_file_close(file);
+    } else {
+        FURI_LOG_W(TAG, "Failed to open settings file: %s. File may not exist or is inaccessible.", storage_file_get_error_desc(file));
+    }
+
+    if(!settings_loaded_successfully) {
+        FURI_LOG_I(TAG, "Applying default settings because loading failed or validation issues.");
+        apply_default_settings(&state->settings);
+        // Attempt to save these default settings to create the file or overwrite a corrupt one.
+        if(flipp_pomodoro_settings_save(state)) {
+            FURI_LOG_I(TAG, "Default settings saved to storage.");
+        } else {
+            FURI_LOG_E(TAG, "Failed to save default settings to storage.");
+        }
+    }
+
+    storage_file_free(file);
+    furi_record_close(RECORD_STORAGE);
+}
+
+bool flipp_pomodoro_settings_save(FlippPomodoroState* state) {
+    furi_assert(state);
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FlipperApplicationFile* file = storage_file_alloc(storage);
+    bool success = false;
+
+    FURI_LOG_I(TAG, "Attempting to save settings to %s", FLIPP_POMODORO_SETTINGS_FILE_PATH);
+
+    if(storage_file_open(file, FLIPP_POMODORO_SETTINGS_FILE_PATH, FSAM_WRITE, FSOM_CREATE_ALWAYS)) {
+        FURI_LOG_D(TAG, "File opened successfully for writing.");
+        size_t bytes_written = storage_file_write(file, &state->settings, sizeof(FlippPomodoroSettings));
+        if(bytes_written == sizeof(FlippPomodoroSettings)) {
+            success = true;
+            FURI_LOG_I(TAG, "Settings saved successfully: W:%u, S:%u, L:%u",
+                state->settings.work_minutes,
+                state->settings.short_break_minutes,
+                state->settings.long_break_minutes);
+        } else {
+            FURI_LOG_E(TAG, "Failed to write complete settings data to file. Expected %d, wrote %d", sizeof(FlippPomodoroSettings), bytes_written);
+        }
+        storage_file_close(file);
+    } else {
+        FURI_LOG_E(TAG, "Failed to open settings file for writing: %s", storage_file_get_error_desc(file));
+    }
+
+    storage_file_free(file);
+    furi_record_close(RECORD_STORAGE);
+    return success;
+}

--- a/flipp_pomodoro/services/flipp_pomodoro_settings_storage.h
+++ b/flipp_pomodoro/services/flipp_pomodoro_settings_storage.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Required for APP_DATA_PATH macro
+#include <flipper_application/flipper_application.h>
+
+// Definition of FlippPomodoroSettings is in modules/flipp_pomodoro.h
+// It's assumed that modules/flipp_pomodoro.h will be included alongside this file
+// when settings storage functions are used.
+
+#define FLIPP_POMODORO_SETTINGS_FILE_NAME "flipp_pomodoro.settings"
+#define FLIPP_POMODORO_SETTINGS_FILE_PATH APP_DATA_PATH(FLIPP_POMODORO_SETTINGS_FILE_NAME)
+
+// Necessary headers for file operations (for the .c file that will implement storage logic):
+// #include <storage/storage.h>
+// #include <furi.h> // For FURI_LOG_ macros if used in storage functions
+
+// Forward declaration for FlippPomodoroState, its definition is in modules/flipp_pomodoro.h
+typedef struct FlippPomodoroState FlippPomodoroState;
+
+/// @brief Loads FlippPomodoro settings from persistent storage.
+/// If loading fails or data is invalid, default settings are applied to the state.
+/// @param state Pointer to the FlippPomodoroState to load settings into.
+void flipp_pomodoro_settings_load(FlippPomodoroState* state);
+
+/// @brief Saves the current settings from FlippPomodoroState to persistent storage.
+/// @param state Pointer to the FlippPomodoroState containing the settings to save.
+/// @return True if settings were saved successfully, false otherwise.
+bool flipp_pomodoro_settings_save(FlippPomodoroState* state);

--- a/flipp_pomodoro/views/flipp_pomodoro_settings_view.c
+++ b/flipp_pomodoro/views/flipp_pomodoro_settings_view.c
@@ -1,0 +1,179 @@
+#include "flipp_pomodoro_settings_view.h"
+#include <gui/elements.h>
+#include <furi.h>
+
+// Define the view structure
+struct FlippPomodoroSettingsView {
+    View* view;
+    FlippPomodoroSettingsViewInputCallback input_callback;
+    void* input_context;
+    uint8_t work_time;
+    uint8_t short_break_time;
+    uint8_t long_break_time;
+    uint8_t selected_item; // 0: Work, 1: Short Break, 2: Long Break
+};
+
+// Draw callback for the view
+static void flipp_pomodoro_settings_view_draw_callback(Canvas* canvas, void* context) {
+    furi_assert(context);
+    FlippPomodoroSettingsView* view = context;
+
+    canvas_clear(canvas);
+    canvas_set_font(canvas, FontSecondary);
+
+    char buffer[16];
+
+    // Display "Work" label and value
+    snprintf(buffer, sizeof(buffer), "Work: %02u", view->work_time);
+    elements_multiline_text_aligned(canvas, 10, 10, AlignLeft, AlignTop, buffer);
+    if (view->selected_item == 0) {
+        elements_frame(canvas, 5, 5, 60, 12); // Highlight selected item
+    }
+
+    // Display "Short Break" label and value
+    snprintf(buffer, sizeof(buffer), "Short Break: %02u", view->short_break_time);
+    elements_multiline_text_aligned(canvas, 10, 25, AlignLeft, AlignTop, buffer);
+    if (view->selected_item == 1) {
+        elements_frame(canvas, 5, 20, 100, 12); // Highlight selected item
+    }
+
+    // Display "Long Break" label and value
+    snprintf(buffer, sizeof(buffer), "Long Break: %02u", view->long_break_time);
+    elements_multiline_text_aligned(canvas, 10, 40, AlignLeft, AlignTop, buffer);
+    if (view->selected_item == 2) {
+        elements_frame(canvas, 5, 35, 100, 12); // Highlight selected item
+    }
+}
+
+// Input callback for the view
+static bool flipp_pomodoro_settings_view_input_callback(InputEvent* event, void* context) {
+    furi_assert(context);
+    FlippPomodoroSettingsView* view = context;
+    bool consumed = false;
+
+    if (event->type == InputTypeShort) {
+        if (event->key == InputKeyUp) {
+            if (view->selected_item > 0) {
+                view->selected_item--;
+            }
+            consumed = true;
+        } else if (event->key == InputKeyDown) {
+            if (view->selected_item < 2) {
+                view->selected_item++;
+            }
+            consumed = true;
+        } else if (event->key == InputKeyLeft) {
+            if (view->selected_item == 0) { // Work
+                if (view->work_time > 0) view->work_time--;
+            } else if (view->selected_item == 1) { // Short Break
+                if (view->short_break_time > 0) view->short_break_time--;
+            } else if (view->selected_item == 2) { // Long Break
+                if (view->long_break_time > 0) view->long_break_time--;
+            }
+            consumed = true;
+        } else if (event->key == InputKeyRight) {
+            if (view->selected_item == 0) { // Work
+                if (view->work_time < 99) view->work_time++;
+            } else if (view->selected_item == 1) { // Short Break
+                if (view->short_break_time < 99) view->short_break_time++;
+            } else if (view->selected_item == 2) { // Long Break
+                if (view->long_break_time < 99) view->long_break_time++;
+            }
+            consumed = true;
+        } else if (event->key == InputKeyOk) {
+            // Placeholder for confirming selection or action
+            // For now, OK button might be used to confirm settings if we change the flow from auto-save on back.
+            // Or it could cycle through fields, or open a specific editor for the field.
+            // Currently, it calls a generic input_callback.
+            // Will be implemented in a later step
+            if (view->input_callback) {
+                view->input_callback(view->input_context);
+            }
+            consumed = true;
+        }
+    }
+
+    if (consumed) {
+        view_commit_models(view->view); // Redraw the view
+    }
+
+    return consumed;
+}
+
+// Allocate and initialize the settings view
+FlippPomodoroSettingsView* flipp_pomodoro_settings_view_alloc() {
+    FlippPomodoroSettingsView* view = malloc(sizeof(FlippPomodoroSettingsView));
+    view->view = view_alloc();
+    view_set_context(view->view, view);
+    view_set_draw_callback(view->view, flipp_pomodoro_settings_view_draw_callback);
+    view_set_input_callback(view->view, flipp_pomodoro_settings_view_input_callback);
+
+    // Initialize with placeholder values
+    view->work_time = 25;
+    view->short_break_time = 5;
+    view->long_break_time = 30;
+    view->selected_item = 0; // Default to selecting "Work"
+
+    return view;
+}
+
+// Free the settings view
+void flipp_pomodoro_settings_view_free(FlippPomodoroSettingsView* view) {
+    furi_assert(view);
+    view_free(view->view);
+    free(view);
+}
+
+// Get the underlying view object
+View* flipp_pomodoro_settings_view_get_view(FlippPomodoroSettingsView* view) {
+    furi_assert(view);
+    return view->view;
+}
+
+// Set placeholder values
+void flipp_pomodoro_settings_view_set_work_time(FlippPomodoroSettingsView* view, uint8_t work_time) {
+    furi_assert(view);
+    if (work_time > 99) work_time = 99; // Constrain to 0-99
+    view->work_time = work_time;
+    view_commit_models(view->view);
+}
+
+void flipp_pomodoro_settings_view_set_short_break_time(FlippPomodoroSettingsView* view, uint8_t short_break_time) {
+    furi_assert(view);
+    if (short_break_time > 99) short_break_time = 99; // Constrain to 0-99
+    view->short_break_time = short_break_time;
+    view_commit_models(view->view);
+}
+
+void flipp_pomodoro_settings_view_set_long_break_time(FlippPomodoroSettingsView* view, uint8_t long_break_time) {
+    furi_assert(view);
+    if (long_break_time > 99) long_break_time = 99; // Constrain to 0-99
+    view->long_break_time = long_break_time;
+    view_commit_models(view->view);
+}
+
+// Set input callback
+void flipp_pomodoro_settings_view_set_input_callback(
+    FlippPomodoroSettingsView* view,
+    FlippPomodoroSettingsViewInputCallback callback,
+    void* context) {
+    furi_assert(view);
+    view->input_callback = callback;
+    view->input_context = context;
+}
+
+// Getter functions for settings values
+uint8_t flipp_pomodoro_settings_view_get_work_time(FlippPomodoroSettingsView* view) {
+    furi_assert(view);
+    return view->work_time;
+}
+
+uint8_t flipp_pomodoro_settings_view_get_short_break_time(FlippPomodoroSettingsView* view) {
+    furi_assert(view);
+    return view->short_break_time;
+}
+
+uint8_t flipp_pomodoro_settings_view_get_long_break_time(FlippPomodoroSettingsView* view) {
+    furi_assert(view);
+    return view->long_break_time;
+}

--- a/flipp_pomodoro/views/flipp_pomodoro_settings_view.h
+++ b/flipp_pomodoro/views/flipp_pomodoro_settings_view.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <gui/view.h>
+
+// Forward declaration of the view structure
+typedef struct FlippPomodoroSettingsView FlippPomodoroSettingsView;
+
+// Callback types for input handling (to be defined later)
+typedef void (*FlippPomodoroSettingsViewInputCallback)(void* context);
+
+// Allocate and initialize the settings view
+FlippPomodoroSettingsView* flipp_pomodoro_settings_view_alloc();
+
+// Free the settings view
+void flipp_pomodoro_settings_view_free(FlippPomodoroSettingsView* view);
+
+// Get the underlying view object
+View* flipp_pomodoro_settings_view_get_view(FlippPomodoroSettingsView* view);
+
+// Set placeholder values (actual data will be passed later)
+void flipp_pomodoro_settings_view_set_work_time(FlippPomodoroSettingsView* view, uint8_t work_time);
+void flipp_pomodoro_settings_view_set_short_break_time(FlippPomodoroSettingsView* view, uint8_t short_break_time);
+void flipp_pomodoro_settings_view_set_long_break_time(FlippPomodoroSettingsView* view, uint8_t long_break_time);
+
+// Set input callbacks (to be defined later)
+void flipp_pomodoro_settings_view_set_input_callback(
+    FlippPomodoroSettingsView* view,
+    FlippPomodoroSettingsViewInputCallback callback,
+    void* context);
+
+// Getter functions for current values from the view's model
+uint8_t flipp_pomodoro_settings_view_get_work_time(FlippPomodoroSettingsView* view);
+uint8_t flipp_pomodoro_settings_view_get_short_break_time(FlippPomodoroSettingsView* view);
+uint8_t flipp_pomodoro_settings_view_get_long_break_time(FlippPomodoroSettingsView* view);


### PR DESCRIPTION
This commit introduces a new settings screen allowing you to configure the duration for Work, Short Break, and Long Break stages.

Key changes:

-   **New Settings Scene & View:**
    -   Added `FlippPomodoroSceneSettings` and its corresponding view `FlippPomodoroSettingsView`.
    -   The view allows you to navigate between Work, Short Break, and Long Break settings using Up/Down keys.
    -   Values for each setting can be adjusted using Left/Right keys (0-99 minutes).
-   **Configurable Timer Logic:**
    -   `FlippPomodoroState` now includes a `FlippPomodoroSettings` struct to store timer durations.
    -   Timer logic in `flipp_pomodoro.c` now uses these settings instead of hardcoded values.
    -   Default values remain 25 (Work), 5 (Short Break), and 30 (Long Break) minutes.
-   **Navigation:**
    -   You can access the settings screen by long-pressing the OK button on the main timer screen.
    -   Pressing the Back button on the settings screen saves the changes and returns to the timer.
-   **Data Flow:**
    -   Settings are loaded into the view when entering the settings screen.
    -   Modified settings are saved back to the application's state upon exiting the settings screen.
-   **Testing Preparation:**
    -   Added `flipp_pomodoro/TESTING.md` outlining test cases for the new functionality, as no existing automated testing framework was found.

This enhancement provides you with greater flexibility in tailoring the Pomodoro timer to your preferences.