### PR TITLE
fix: gh-actions workflow missing permissions 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Bump and Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.13.1


### PR DESCRIPTION
Potential fix for [https://github.com/Th3Un1q3/flipp_pomodoro/security/code-scanning/1](https://github.com/Th3Un1q3/flipp_pomodoro/security/code-scanning/1)

In general, the problem is fixed by adding a `permissions` block either at the workflow root or at the job level to explicitly scope what the `GITHUB_TOKEN` can do. For a release workflow that tags commits and creates GitHub Releases, the token needs write access to repository contents and releases (which fall under `contents: write`). It does not obviously need permissions like `issues`, `pull-requests`, or `packages`, so those should be left unset.

The best way to fix this specific workflow without changing functionality is to add a `permissions` block at the job level for `build`, just under the `runs-on` key. That keeps the scope clear and avoids affecting other jobs if they are ever added later. The job uses actions that push tags and create releases, so `contents: write` is required; there is no evidence that additional scopes are needed. Concretely, in `.github/workflows/release.yml`, between line 10 (`runs-on: ubuntu-latest`) and line 11 (`steps:`), insert:

```yaml
    permissions:
      contents: write
```

No imports or additional methods are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
